### PR TITLE
Adding support for specifing storage class for IxS3FileSystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ hs_err_pid*
 *.iml
 *.ipr
 *.iws
+.idea/

--- a/hadoop-mr-s3/src/main/java/org/apache/hadoop/fs/IxS3FileSystem.java
+++ b/hadoop-mr-s3/src/main/java/org/apache/hadoop/fs/IxS3FileSystem.java
@@ -2,6 +2,7 @@ package org.apache.hadoop.fs;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.fs.s3native.Jets3tNFSStoreWithStorageClassSupport;
 import org.apache.hadoop.fs.s3native.NativeS3FileSystem;
 import org.apache.hadoop.util.Progressable;
 
@@ -21,7 +22,7 @@ public class IxS3FileSystem extends FileSystem {
     }
 
     public IxS3FileSystem() {
-        nativeFS = new NativeS3FileSystem();
+        nativeFS = new NativeS3FileSystem(new Jets3tNFSStoreWithStorageClassSupport());
     }
 
     @Override

--- a/hadoop-mr-s3/src/main/java/org/apache/hadoop/fs/IxS3NativeFileSystemWithStorageClass.java
+++ b/hadoop-mr-s3/src/main/java/org/apache/hadoop/fs/IxS3NativeFileSystemWithStorageClass.java
@@ -1,0 +1,104 @@
+package org.apache.hadoop.fs;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.fs.s3native.Jets3tNFSStoreWithStorageClassSupport;
+import org.apache.hadoop.fs.s3native.NativeS3FileSystem;
+import org.apache.hadoop.util.Progressable;
+
+import java.io.IOException;
+import java.net.URI;
+
+/**
+ * Wrapper over {@see NativeS3FileSystem} to provide S3 storage class support via fs.s3n.storage.class
+ * configuration property.
+ */
+public class IxS3NativeFileSystemWithStorageClass extends FileSystem {
+    private Path workingDir;
+    private NativeS3FileSystem nativeFS;
+    private URI uri;
+
+    public IxS3NativeFileSystemWithStorageClass(NativeS3FileSystem fileSystem) {
+        nativeFS = fileSystem;
+    }
+
+    public IxS3NativeFileSystemWithStorageClass() {
+        nativeFS = new NativeS3FileSystem(new Jets3tNFSStoreWithStorageClassSupport());
+    }
+
+    @Override
+    public URI getUri() {
+        //Change this
+        return this.uri;
+    }
+
+    @Override
+    public void initialize(URI uri, Configuration conf) throws IOException {
+        this.uri = uri;
+        nativeFS.initialize(uri, conf);
+        setConf(conf);
+        super.initialize(uri, conf);
+    }
+
+    @Override
+    public FSDataInputStream open(Path path, int bufferSize) throws IOException {
+        return nativeFS.open(path, bufferSize);
+    }
+
+    @Override
+    public boolean exists(Path path) throws IOException {
+        return nativeFS.exists(path);
+    }
+
+    @Override
+    public FSDataOutputStream create(Path path, FsPermission fsPermission, boolean overwrite, int bufferSize, short replication, long blockSize,
+                                     Progressable progress) throws IOException {
+        return nativeFS.create(path, fsPermission, overwrite, bufferSize, replication, blockSize, progress);
+    }
+
+    @Override
+    public FSDataOutputStream append(Path path, int i, Progressable progressable) throws IOException {
+        throw new IOException("Not supported in NativeS3FileSystem, since optional");
+    }
+
+    @Override
+    public boolean rename(Path from, Path to) throws IOException {
+        return nativeFS.rename(from, to);
+    }
+
+    @Override
+    public boolean delete(Path path, boolean recursive) throws IOException {
+        return nativeFS.delete(path, recursive);
+    }
+
+    @Override
+    public FileStatus[] listStatus(Path path) throws IOException {
+        return nativeFS.listStatus(path);
+    }
+
+    @Override
+    public void setWorkingDirectory(Path path) {
+        this.workingDir = path;
+    }
+
+    @Override
+    public Path getWorkingDirectory() {
+        return this.workingDir;
+    }
+
+    @Override
+    public boolean mkdirs(Path path, FsPermission fsPermission) throws IOException {
+        return nativeFS.mkdirs(path, fsPermission);
+    }
+
+    @Override
+    public FileStatus getFileStatus(Path path) throws IOException {
+        return nativeFS.getFileStatus(path);
+    }
+
+    @Override
+    public void close() throws IOException {
+        nativeFS.close();
+        super.close();
+    }
+}

--- a/hadoop-mr-s3/src/main/java/org/apache/hadoop/fs/s3native/Jets3tNFSStoreWithStorageClassSupport.java
+++ b/hadoop-mr-s3/src/main/java/org/apache/hadoop/fs/s3native/Jets3tNFSStoreWithStorageClassSupport.java
@@ -1,0 +1,312 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3native;
+
+import static org.apache.hadoop.fs.s3native.NativeS3FileSystem.PATH_DELIMITER;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.EOFException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSExceptionMessages;
+import org.apache.hadoop.fs.s3.S3Credentials;
+import org.apache.hadoop.fs.s3.S3Exception;
+import org.apache.hadoop.io.IOUtils;
+import org.apache.hadoop.security.AccessControlException;
+import org.jets3t.service.S3Service;
+import org.jets3t.service.S3ServiceException;
+import org.jets3t.service.ServiceException;
+import org.jets3t.service.StorageObjectsChunk;
+import org.jets3t.service.impl.rest.HttpException;
+import org.jets3t.service.impl.rest.httpclient.RestS3Service;
+import org.jets3t.service.model.MultipartPart;
+import org.jets3t.service.model.MultipartUpload;
+import org.jets3t.service.model.S3Bucket;
+import org.jets3t.service.model.S3Object;
+import org.jets3t.service.model.StorageObject;
+import org.jets3t.service.security.AWSCredentials;
+import org.jets3t.service.utils.MultipartUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@InterfaceAudience.Private
+@InterfaceStability.Unstable
+public class Jets3tNFSStoreWithStorageClassSupport extends Jets3tNativeFileSystemStore {
+
+  private S3Service s3Service;
+  private S3Bucket bucket;
+  private S3StorageClass storageClass;
+
+  private long multipartBlockSize;
+  private boolean multipartEnabled;
+  private long multipartCopyBlockSize;
+  static final long MAX_PART_SIZE = (long)5 * 1024 * 1024 * 1024;
+
+  private String serverSideEncryptionAlgorithm;
+
+  public static final Logger LOG =
+          LoggerFactory.getLogger(Jets3tNativeFileSystemStore.class);
+
+  @Override
+  public void initialize(URI uri, Configuration conf) throws IOException {
+    S3Credentials s3Credentials = new S3Credentials();
+    s3Credentials.initialize(uri, conf);
+    try {
+      AWSCredentials awsCredentials =
+              new AWSCredentials(s3Credentials.getAccessKey(),
+                      s3Credentials.getSecretAccessKey());
+      this.s3Service = new RestS3Service(awsCredentials);
+    } catch (S3ServiceException e) {
+      handleException(e);
+    }
+    multipartEnabled =
+            conf.getBoolean("fs.s3n.multipart.uploads.enabled", false);
+    multipartBlockSize = Math.min(
+            conf.getLong("fs.s3n.multipart.uploads.block.size", 64 * 1024 * 1024),
+            MAX_PART_SIZE);
+    multipartCopyBlockSize = Math.min(
+            conf.getLong("fs.s3n.multipart.copy.block.size", MAX_PART_SIZE),
+            MAX_PART_SIZE);
+    serverSideEncryptionAlgorithm = conf.get("fs.s3n.server-side-encryption-algorithm");
+    // Acceptable values are - standard, glacier, rrs, standard-ia
+    storageClass = S3StorageClass.get(conf.get("fs.s3n.storage.class", "standard"));
+
+    bucket = new S3Bucket(uri.getHost());
+  }
+
+  @Override
+  public void storeFile(String key, File file, byte[] md5Hash)
+          throws IOException {
+
+    if (multipartEnabled && file.length() >= multipartBlockSize) {
+      storeLargeFile(key, file, md5Hash);
+      return;
+    }
+
+    BufferedInputStream in = null;
+    try {
+      in = new BufferedInputStream(new FileInputStream(file));
+      S3Object object = new S3Object(key);
+      object.setStorageClass(storageClass.getStorageClass());
+      object.setDataInputStream(in);
+      object.setContentType("binary/octet-stream");
+      object.setContentLength(file.length());
+      object.setServerSideEncryptionAlgorithm(serverSideEncryptionAlgorithm);
+      if (md5Hash != null) {
+        object.setMd5Hash(md5Hash);
+      }
+      s3Service.putObject(bucket, object);
+    } catch (ServiceException e) {
+      handleException(e, key);
+    } finally {
+      IOUtils.closeStream(in);
+    }
+  }
+
+  public void storeLargeFile(String key, File file, byte[] md5Hash)
+          throws IOException {
+    S3Object object = new S3Object(key);
+    object.setStorageClass(storageClass.getStorageClass());
+    object.setDataInputFile(file);
+    object.setContentType("binary/octet-stream");
+    object.setContentLength(file.length());
+    object.setServerSideEncryptionAlgorithm(serverSideEncryptionAlgorithm);
+    if (md5Hash != null) {
+      object.setMd5Hash(md5Hash);
+    }
+
+    List<StorageObject> objectsToUploadAsMultipart =
+            new ArrayList<StorageObject>();
+    objectsToUploadAsMultipart.add(object);
+    MultipartUtils mpUtils = new MultipartUtils(multipartBlockSize);
+
+    try {
+      mpUtils.uploadObjects(bucket.getName(), s3Service,
+              objectsToUploadAsMultipart, null);
+    } catch (Exception e) {
+      handleException(e, key);
+    }
+  }
+
+  @Override
+  public void storeEmptyFile(String key) throws IOException {
+    try {
+      S3Object object = new S3Object(key);
+      object.setStorageClass(storageClass.getStorageClass());
+      object.setDataInputStream(new ByteArrayInputStream(new byte[0]));
+      object.setContentType("binary/octet-stream");
+      object.setContentLength(0);
+      object.setServerSideEncryptionAlgorithm(serverSideEncryptionAlgorithm);
+      s3Service.putObject(bucket, object);
+    } catch (ServiceException e) {
+      handleException(e, key);
+    }
+  }
+
+  public void copyLargeFile(S3Object srcObject, String dstKey) throws IOException {
+    try {
+      long partCount = srcObject.getContentLength() / multipartCopyBlockSize +
+              (srcObject.getContentLength() % multipartCopyBlockSize > 0 ? 1 : 0);
+
+      MultipartUpload multipartUpload = s3Service.multipartStartUpload
+              (bucket.getName(), dstKey, srcObject.getMetadataMap(), null, storageClass.getStorageClass());
+
+      List<MultipartPart> listedParts = new ArrayList<MultipartPart>();
+      for (int i = 0; i < partCount; i++) {
+        long byteRangeStart = i * multipartCopyBlockSize;
+        long byteLength;
+        if (i < partCount - 1) {
+          byteLength = multipartCopyBlockSize;
+        } else {
+          byteLength = srcObject.getContentLength() % multipartCopyBlockSize;
+          if (byteLength == 0) {
+            byteLength = multipartCopyBlockSize;
+          }
+        }
+
+        MultipartPart copiedPart = s3Service.multipartUploadPartCopy
+                (multipartUpload, i + 1, bucket.getName(), srcObject.getKey(),
+                        null, null, null, null, byteRangeStart,
+                        byteRangeStart + byteLength - 1, null);
+        listedParts.add(copiedPart);
+      }
+
+      Collections.reverse(listedParts);
+      s3Service.multipartCompleteUpload(multipartUpload, listedParts);
+    } catch (ServiceException e) {
+      handleException(e, srcObject.getKey());
+    }
+  }
+
+  @Override
+  public void dump() throws IOException {
+    StringBuilder sb = new StringBuilder("S3 Native Filesystem, ");
+    sb.append(bucket.getName()).append("\n");
+    try {
+      S3Object[] objects = s3Service.listObjects(bucket.getName());
+      for (S3Object object : objects) {
+        sb.append(object.getKey()).append("\n");
+      }
+    } catch (S3ServiceException e) {
+      handleException(e);
+    }
+    System.out.println(sb);
+  }
+
+  /**
+   * Handle any service exception by translating it into an IOException
+   * @param e exception
+   * @throws IOException exception -always
+   */
+  private void handleException(Exception e) throws IOException {
+    throw processException(e, e, "");
+  }
+  /**
+   * Handle any service exception by translating it into an IOException
+   * @param e exception
+   * @param key key sought from object store
+
+   * @throws IOException exception -always
+   */
+  private void handleException(Exception e, String key) throws IOException {
+    throw processException(e, e, key);
+  }
+
+  /**
+   * Handle any service exception by translating it into an IOException
+   * @param thrown exception
+   * @param original original exception -thrown if no other translation could
+   * be made
+   * @param key key sought from object store or "" for undefined
+   * @return an exception to throw. If isProcessingCause==true this may be null.
+   */
+  private IOException processException(Throwable thrown, Throwable original,
+                                       String key) {
+    IOException result;
+    if (thrown.getCause() != null) {
+      // recurse down
+      result = processException(thrown.getCause(), original, key);
+    } else if (thrown instanceof HttpException) {
+      // nested HttpException - examine error code and react
+      HttpException httpException = (HttpException) thrown;
+      String responseMessage = httpException.getResponseMessage();
+      int responseCode = httpException.getResponseCode();
+      String bucketName = "s3n://" + bucket.getName();
+      String text = String.format("%s : %03d : %s",
+              bucketName,
+              responseCode,
+              responseMessage);
+      String filename = !key.isEmpty() ? (bucketName + "/" + key) : text;
+      IOException ioe;
+      switch (responseCode) {
+        case 404:
+          result = new FileNotFoundException(filename);
+          break;
+        case 416: // invalid range
+          result = new EOFException(FSExceptionMessages.CANNOT_SEEK_PAST_EOF
+                  +": " + filename);
+          break;
+        case 403: //forbidden
+          result = new AccessControlException("Permission denied"
+                  +": " + filename);
+          break;
+        default:
+          result = new IOException(text);
+      }
+      result.initCause(thrown);
+    } else if (thrown instanceof S3ServiceException) {
+      S3ServiceException se = (S3ServiceException) thrown;
+      LOG.debug(
+              "S3ServiceException: {}: {} : {}",
+              se.getS3ErrorCode(), se.getS3ErrorMessage(), se, se);
+      if ("InvalidRange".equals(se.getS3ErrorCode())) {
+        result = new EOFException(FSExceptionMessages.CANNOT_SEEK_PAST_EOF);
+      } else {
+        result = new S3Exception(se);
+      }
+    } else if (thrown instanceof ServiceException) {
+      ServiceException se = (ServiceException) thrown;
+      LOG.debug("S3ServiceException: {}: {} : {}",
+              se.getErrorCode(), se.toString(), se, se);
+      result = new S3Exception(se);
+    } else if (thrown instanceof IOException) {
+      result = (IOException) thrown;
+    } else {
+      // here there is no exception derived yet.
+      // this means no inner cause, and no translation made yet.
+      // convert the original to an IOException -rather than just the
+      // exception at the base of the tree
+      result = new S3Exception(original);
+    }
+
+    return result;
+  }
+}

--- a/hadoop-mr-s3/src/main/java/org/apache/hadoop/fs/s3native/Jets3tNFSStoreWithStorageClassSupport.java
+++ b/hadoop-mr-s3/src/main/java/org/apache/hadoop/fs/s3native/Jets3tNFSStoreWithStorageClassSupport.java
@@ -77,6 +77,7 @@ public class Jets3tNFSStoreWithStorageClassSupport extends Jets3tNativeFileSyste
 
   @Override
   public void initialize(URI uri, Configuration conf) throws IOException {
+    super.initialize(uri, conf);
     S3Credentials s3Credentials = new S3Credentials();
     s3Credentials.initialize(uri, conf);
     try {

--- a/hadoop-mr-s3/src/main/java/org/apache/hadoop/fs/s3native/S3StorageClass.java
+++ b/hadoop-mr-s3/src/main/java/org/apache/hadoop/fs/s3native/S3StorageClass.java
@@ -24,6 +24,7 @@ public enum S3StorageClass {
         else if (StringUtils.equalsIgnoreCase(storageClass, "standard")) return STANDARD;
         else if (StringUtils.equalsIgnoreCase(storageClass, "rrs")) return REDUCED_REDUNDANCY;
         else if (StringUtils.equalsIgnoreCase(storageClass, "glacier")) return GLACIER;
+        // TODO - Can we directly write on Standard-IA storage on S3 or should it always be moved via LifeCycle?
         else if (StringUtils.equalsIgnoreCase(storageClass, "standard-ia")) return STANDARD_IA;
         else throw new RuntimeException("Invalid Storage class specified - " + storageClass);
     }

--- a/hadoop-mr-s3/src/main/java/org/apache/hadoop/fs/s3native/S3StorageClass.java
+++ b/hadoop-mr-s3/src/main/java/org/apache/hadoop/fs/s3native/S3StorageClass.java
@@ -1,0 +1,30 @@
+package org.apache.hadoop.fs.s3native;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+
+public enum S3StorageClass {
+    REDUCED_REDUNDANCY("REDUCED_REDUNDANCY"),
+    STANDARD("STANDARD"),
+    GLACIER("GLACIER"),
+    STANDARD_IA("STANDARD_IA");
+
+    private String storageClass;
+
+    S3StorageClass(String name) {
+        this.storageClass = name;
+    }
+
+    public String getStorageClass() {
+        return storageClass;
+    }
+
+    public static S3StorageClass get(String storageClass) {
+        if(StringUtils.isBlank(storageClass)) return STANDARD;
+        else if (StringUtils.equalsIgnoreCase(storageClass, "standard")) return STANDARD;
+        else if (StringUtils.equalsIgnoreCase(storageClass, "rrs")) return REDUCED_REDUNDANCY;
+        else if (StringUtils.equalsIgnoreCase(storageClass, "glacier")) return GLACIER;
+        else if (StringUtils.equalsIgnoreCase(storageClass, "standard-ia")) return STANDARD_IA;
+        else throw new RuntimeException("Invalid Storage class specified - " + storageClass);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
     </modules>
 
     <properties>
-        <hadoop.mr1.version>2.0.0-mr1-cdh4.2.1</hadoop.mr1.version>
-        <hadoop.version>2.0.0-cdh4.2.1</hadoop.version>
+        <hadoop.mr1.version>2.6.0-mr1-cdh5.4.4</hadoop.mr1.version>
+        <hadoop.version>2.6.0-cdh5.4.4</hadoop.version>
     </properties>
   
     <repositories>
@@ -24,19 +24,11 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-core</artifactId>
-            <version>${hadoop.mr1.version}</version>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
             <version>${hadoop.mr1.version}</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
@@ -46,7 +38,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-hdfs</artifactId>
+            <artifactId>hadoop-aws</artifactId>
             <version>${hadoop.version}</version>
             <scope>provided</scope>
             <optional>true</optional>


### PR DESCRIPTION
We can specify the storage class using `fs.s3n.storage.class` config property. Acceptable values are
- standard
- rrs
- glacier
- standard_ia

If none is specified the default is Standard storage class. 

Changes include 
- Upgraded Hadoop versions to our CDH5 installation, because the CDH4 came with 2 years old jets3t libraries which doesn't support storage classes at all. I had an option to choose between shading newer version of jets3t into the module or keep the artifact light and use the one that came along with Hadoop. I choose this approach since I don't see us this on the older clusters.
- Wrote an extension to Jets3tNativeFileSystemStore to proxy all put requests to add storage class. 

I would have liked to move to S3AFileSystem instead of S3NativeFileSystem, but looks like s3a still has some issues (https://issues.apache.org/jira/browse/HADOOP-11694) and would take some time to evolve and stabilise.

I'll test these changes and post the result soon. 
